### PR TITLE
Slight API change to legacygp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ parts/
 sdist/
 var/
 docs/generated/
+demos/_revrand_data/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/demos/demo_gp.py
+++ b/demos/demo_gp.py
@@ -32,7 +32,7 @@ def main():
     # ----------------------------------------------------------
 
     # Define a pathological GP kernel:
-    def kernel_defn(h, k):
+    def kerneldef(h, k):
         a = h(0.1, 5, 0.1)
         b = h(0.1, 5, 0.1)
         logsigma = h(-6, 1)
@@ -40,14 +40,14 @@ def main():
                 + k(gp.kernels.lognoise, logsigma))
 
     # Learning signal and noise hyperparameters
-    hyper_params = gp.learn(X, ys, kernel_defn, verbose=False, ftol=1e-15,
+    hyper_params = gp.learn(X, ys, kerneldef, verbose=False, ftol=1e-15,
                             maxiter=2000)
 
     # old_hyper_params = [1.48, .322, np.log(0.0486)]
-    # print(gp.describe(kernel_defn, old_hyper_params))
-    print(gp.describe(kernel_defn, hyper_params))
+    # print(gp.describe(kerneldef, old_hyper_params))
+    print(gp.describe(kerneldef, hyper_params))
 
-    regressor = gp.condition(X, ys, kernel_defn, hyper_params)
+    regressor = gp.condition(X, ys, kerneldef, hyper_params)
     query = gp.query(regressor, Xs)
     post_mu = gp.mean(query) + data_mean
     # post_cov = gp.covariance(query)

--- a/demos/demo_gp_2d.py
+++ b/demos/demo_gp_2d.py
@@ -36,18 +36,18 @@ def main():
     Xs = np.vstack((xv.ravel(), yv.ravel())).T
 
     # Compose isotropic kernel:
-    def kernel_defn(h, k):
+    def kerneldef(h, k):
         a = h(0.1, 5, 0.1)
         b = h(0.1, 5, 0.1)
         logsigma = h(-6, 1)
         return a*k(gp.kernels.gaussian, b) + k(gp.kernels.lognoise, logsigma)
 
-    hyper_params = gp.learn(X, ys, kernel_defn, verbose=True, ftol=1e-5,
+    hyper_params = gp.learn(X, ys, kerneldef, verbose=True, ftol=1e-5,
                             maxiter=2000)
 
-    print(gp.describe(kernel_defn, hyper_params))
+    print(gp.describe(kerneldef, hyper_params))
 
-    regressor = gp.condition(X, ys, kernel_defn, hyper_params)
+    regressor = gp.condition(X, ys, kerneldef, hyper_params)
 
     query = gp.query(regressor, Xs)
     post_mu = gp.mean(query) + data_mean

--- a/revrand/legacygp/dtypes.py
+++ b/revrand/legacygp/dtypes.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-Range = namedtuple('Range', 'lowerBound upperBound initialVal')
+Range = namedtuple('Range', 'lower_bound upper_bound initial_val')
 
 QueryParams = namedtuple('GPQuery', 'regressor Xs K_xxs')
 

--- a/revrand/legacygp/linalg.py
+++ b/revrand/legacygp/linalg.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def svdInverse(factorisation):
+def svd_inverse(factorisation):
     R, s, Rt = factorisation
     # R, S, RT = np.linalg.svd(K)
     ss = 1./np.sqrt(s)
@@ -22,14 +22,14 @@ def svd_yKy(factorisation, y):
     return np.sum(F**2)
 
 
-def svdLogDet(factorisation):
+def svd_log_det(factorisation):
     """ Computes log determinant for a svd factorisation
     """
     R, s, Rt = factorisation
     return np.sum(np.log(s))
 
 
-def svdSolve(factorisation, M):
+def svd_solve(factorisation, M):
     """ Computes A\M for factorisation = np.linalg.svd(A)
     """
     R, s, Rt = factorisation
@@ -46,7 +46,7 @@ def svdSolve(factorisation, M):
         return R2.dot(R2.T).dot(M)  # O(n^2 (m + n))
 
 
-def svdHalfSolve(factorisation, M):
+def svd_half_solve(factorisation, M):
     """ Computes A\M for factorisation = np.linalg.svd(A)
     """
     R, s, Rt = factorisation


### PR DESCRIPTION
Making naming conventions consistent

Make sure that other projects that uses legacygp are updated with the API change before accepting this pull request

The changes are as follows.

Things that changes the API:

- optCriterion -> opt_criterion (keyword option for learn)
- isNoise -> is_noise
- Range.lowerBound -> Range.lower_bound
- Range.upperBound -> Range.upper_bound
- Range.initialVal -> Range.initial_val
- svdInverse -> svd_inverse
- svdLogDet -> svd_log_det
- svdSolve -> svd_solve
- svdHalfSolve -> svd_half_solve



Things that are internal and do not change the API:

- kernel_defn -> kerneldef
- queryParams - query_params

